### PR TITLE
Fix pawn promotion handling in bitboard engine

### DIFF
--- a/python-implementation/engine/bitboard/board.py
+++ b/python-implementation/engine/bitboard/board.py
@@ -6,9 +6,30 @@ from engine.bitboard.constants import (
     INITIAL_MASKS,
     WHITE_PAWN,
     BLACK_PAWN,
+    WHITE_KNIGHT,
+    WHITE_BISHOP,
+    WHITE_ROOK,
+    WHITE_QUEEN,
+    BLACK_KNIGHT,
+    BLACK_BISHOP,
+    BLACK_ROOK,
+    BLACK_QUEEN,
     WHITE,
     BLACK,
 )
+
+PROMO_MAP_WHITE = {
+    "N": WHITE_KNIGHT,
+    "B": WHITE_BISHOP,
+    "R": WHITE_ROOK,
+    "Q": WHITE_QUEEN,
+}
+PROMO_MAP_BLACK = {
+    "N": BLACK_KNIGHT,
+    "B": BLACK_BISHOP,
+    "R": BLACK_ROOK,
+    "Q": BLACK_QUEEN,
+}
 
 
 class Board:
@@ -142,7 +163,12 @@ class Board:
         if captured_idx is not None:
             self.bitboards[captured_idx] ^= 1 << cap_sq
 
-        self.bitboards[piece_idx] |= 1 << dst
+        target_idx = piece_idx
+        if move.promotion:
+            promo_map = PROMO_MAP_WHITE if piece_idx < 6 else PROMO_MAP_BLACK
+            target_idx = promo_map[move.promotion]
+
+        self.bitboards[target_idx] |= 1 << dst
         self.update_occupancies()
         self.side_to_move = BLACK if self.side_to_move == WHITE else WHITE
 
@@ -163,9 +189,14 @@ class Board:
         assert moved_idx is not None
 
         self.bitboards[moved_idx] ^= 1 << dst
-        self.bitboards[moved_idx] |= 1 << src
+        if move.promotion:
+            pawn_idx = WHITE_PAWN if moved_idx < 6 else BLACK_PAWN
+            self.bitboards[pawn_idx] |= 1 << src
+        else:
+            self.bitboards[moved_idx] |= 1 << src
 
         if undo.captured_idx is not None:
             self.bitboards[undo.captured_idx] |= 1 << undo.cap_sq
 
         self.update_occupancies()
+

--- a/python-implementation/engine/bitboard/moves/pawn.py
+++ b/python-implementation/engine/bitboard/moves/pawn.py
@@ -114,7 +114,13 @@ def generate_pawn_moves(
         while tmp:
             dest = pop_lsb(tmp)
             src = dest - step if is_white else dest + step
-            moves.append(Move(src, dest))
+            if step == 8 and (
+                (is_white and dest >= 56) or (not is_white and dest < 8)
+            ):
+                for promo in ("Q", "R", "B", "N"):
+                    moves.append(Move(src, dest, promotion=promo))
+            else:
+                moves.append(Move(src, dest))
             tmp &= tmp - 1
 
     # --- Captures ---
@@ -127,7 +133,11 @@ def generate_pawn_moves(
         else:
             src = dest + 9 if ((pawns_bb >> (dest + 9)) & 1) else dest + 7
 
-        moves.append(Move(src, dest, capture=True))
+        if (is_white and dest >= 56) or (not is_white and dest < 8):
+            for promo in ("Q", "R", "B", "N"):
+                moves.append(Move(src, dest, capture=True, promotion=promo))
+        else:
+            moves.append(Move(src, dest, capture=True))
         tmp &= tmp - 1
 
     ep_bb = pawn_en_passant_targets(pawns_bb, ep_mask, is_white)

--- a/python-implementation/tests/bitboard_tests/test_make_undo.py
+++ b/python-implementation/tests/bitboard_tests/test_make_undo.py
@@ -9,6 +9,7 @@ from engine.bitboard.constants import (
     WHITE,
     BLACK,
     WHITE_KNIGHT,
+    WHITE_QUEEN,
 )
 
 
@@ -141,3 +142,19 @@ def test_undo_without_history_raises():
     board = Board()
     with pytest.raises(IndexError):
         board.undo_move()
+
+
+def test_pawn_promotion_round_trip():
+    board = Board()
+    board.bitboards = [0] * 12
+    board.bitboards[WHITE_PAWN] = 1 << 48  # a7
+    board.update_occupancies()
+    board.side_to_move = WHITE
+
+    before = snapshot(board)
+    mv = Move(src=48, dst=56, capture=False, promotion="Q")
+    board.make_move(mv)
+    assert board.bitboards[WHITE_PAWN] == 0
+    assert (board.bitboards[WHITE_QUEEN] & (1 << 56)) != 0
+    board.undo_move()
+    restore_ok(board, before)

--- a/python-implementation/tests/bitboard_tests/test_pawn.py
+++ b/python-implementation/tests/bitboard_tests/test_pawn.py
@@ -241,3 +241,17 @@ def test_pawn_en_passant_masking_high_bits():
     assert (
         result == ep_mask
     )  # should still match despite infinite-precision bits
+
+
+def test_generate_white_pawn_promotion_moves():
+    pawns = 1 << 48  # a7
+    moves = generate_pawn_moves(pawns, 0, pawns, True)
+    promos = {m.promotion for m in moves}
+    assert promos == {"Q", "R", "B", "N"}
+
+
+def test_generate_black_pawn_promotion_moves():
+    pawns = 1 << 15  # h2
+    moves = generate_pawn_moves(pawns, 0, pawns, False)
+    promos = {m.promotion for m in moves}
+    assert promos == {"Q", "R", "B", "N"}


### PR DESCRIPTION
## Summary
- add promotion move generation for bitboard pawns
- support promotions in Board make/undo logic
- test promotion move generation and undo round-trip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5f61980c83319ac189e757f568c5