### PR TITLE
Fix en passant edge case test pawn placement

### DIFF
--- a/python-implementation/tests/mailbox_tests/test_edge_cases.py
+++ b/python-implementation/tests/mailbox_tests/test_edge_cases.py
@@ -33,7 +33,7 @@ def test_en_passant_exposes_check():
     b = make_board(
         {
             (5, 5): "P",  # e5
-            (6, 5): "p",  # f5
+            (6, 7): "p",  # f7
             (5, 1): "K",  # e1
             (5, 8): "r",  # e8 (attacking down the file if e5 is cleared)
         }


### PR DESCRIPTION
## Summary
- fix pawn starting square in `test_en_passant_exposes_check`

## Testing
- `pytest -q tests/mailbox_tests/test_edge_cases.py::test_en_passant_exposes_check`

------
https://chatgpt.com/codex/tasks/task_e_683f65f4f1cc8331aac244278bdc6094