### PR TITLE
Add tests for missing bitboard cases

### DIFF
--- a/python-implementation/tests/bitboard_tests/test_bitboard_init.py
+++ b/python-implementation/tests/bitboard_tests/test_bitboard_init.py
@@ -29,3 +29,18 @@ def test_initial_bitboards(board):
         assert (
             board.bitboards[idx] == expected
         ), f"bitboards[{idx}] mismatch: got {hex(board.bitboards[idx])}, expected {hex(expected)}"  # noqa: E501
+
+
+def test_initial_occupancies(board):
+    """Verify white, black and overall occupancy after initialization."""
+    expected_white = 0
+    for i in range(6):
+        expected_white |= INITIAL_MASKS[i]
+    expected_black = 0
+    for i in range(6, 12):
+        expected_black |= INITIAL_MASKS[i]
+    expected_all = expected_white | expected_black
+
+    assert board.white_occ == expected_white
+    assert board.black_occ == expected_black
+    assert board.all_occ == expected_all

--- a/python-implementation/tests/bitboard_tests/test_knight.py
+++ b/python-implementation/tests/bitboard_tests/test_knight.py
@@ -86,3 +86,11 @@ def test_generate_knight_moves_capture_flag():
     # Check non-capture moves are present with capture=False
     non_caps = [m for m in moves if not m.capture]
     assert all(not m.capture for m in non_caps)
+
+
+def test_knight_moves_ignore_friendly():
+    sq = 28  # e4
+    knights = 1 << sq
+    my_occ = knights | (1 << 38)  # friendly piece on g5
+    moves = generate_knight_moves(knights, my_occ, 0)
+    assert all(m.dst != 38 for m in moves)

--- a/python-implementation/tests/bitboard_tests/test_magics.py
+++ b/python-implementation/tests/bitboard_tests/test_magics.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-"""
-Verify that saved magic tables reproduce the reference attack generator.
-Run after `python -m engine.bitboard.build_magics`.
-"""
+"""Tests for correctness of saved magic tables."""
+
+import pytest
 
 from engine.bitboard.magic_constants import (
     RELEVANT_ROOK_MASKS,
@@ -68,6 +67,32 @@ def verify(piece: str):
                     f"!= ref 0x{attack_ref:016x}"
                 )
     print(f"All {piece} magics verified.")
+
+
+@pytest.mark.parametrize("sq", [0, 27, 63])
+def test_rook_magic_subset(sq):
+    mask = RELEVANT_ROOK_MASKS[sq]
+    magic = ROOK_MAGICS[sq]
+    shift = ROOK_SHIFTS[sq]
+    table = ROOK_ATTACK_TABLE[sq]
+    for subset in [0, 1, (1 << bit_count(mask)) - 1]:
+        occ = expand_occupancy(subset, mask)
+        idx = ((occ * magic) & MASK64) >> shift
+        ref = compute_rook_attacks_with_blockers(sq, occ)
+        assert table[idx] == ref
+
+
+@pytest.mark.parametrize("sq", [0, 27, 63])
+def test_bishop_magic_subset(sq):
+    mask = RELEVANT_BISHOP_MASKS[sq]
+    magic = BISHOP_MAGICS[sq]
+    shift = BISHOP_SHIFTS[sq]
+    table = BISHOP_ATTACK_TABLE[sq]
+    for subset in [0, 1, (1 << bit_count(mask)) - 1]:
+        occ = expand_occupancy(subset, mask)
+        idx = ((occ * magic) & MASK64) >> shift
+        ref = compute_bishop_attacks_with_blockers(sq, occ)
+        assert table[idx] == ref
 
 
 def main():

--- a/python-implementation/tests/bitboard_tests/test_make_undo.py
+++ b/python-implementation/tests/bitboard_tests/test_make_undo.py
@@ -10,6 +10,7 @@ from engine.bitboard.constants import (
     BLACK,
     WHITE_KNIGHT,
     WHITE_QUEEN,
+    BLACK_ROOK,
 )
 
 
@@ -156,5 +157,24 @@ def test_pawn_promotion_round_trip():
     board.make_move(mv)
     assert board.bitboards[WHITE_PAWN] == 0
     assert (board.bitboards[WHITE_QUEEN] & (1 << 56)) != 0
+    board.undo_move()
+    restore_ok(board, before)
+
+
+def test_capture_promotion_round_trip():
+    board = Board()
+    board.bitboards = [0] * 12
+    board.bitboards[WHITE_PAWN] = 1 << 54  # g7
+    board.bitboards[BLACK_ROOK] = 1 << 63  # h8
+    board.update_occupancies()
+    board.side_to_move = WHITE
+
+    before = snapshot(board)
+    mv = Move(src=54, dst=63, capture=True, promotion="Q")
+    board.make_move(mv)
+    assert board.bitboards[WHITE_PAWN] == 0
+    assert (board.bitboards[WHITE_QUEEN] & (1 << 63)) != 0
+    assert (board.bitboards[BLACK_ROOK] & (1 << 63)) == 0
+
     board.undo_move()
     restore_ok(board, before)

--- a/python-implementation/tests/bitboard_tests/test_pawn.py
+++ b/python-implementation/tests/bitboard_tests/test_pawn.py
@@ -95,6 +95,48 @@ def test_black_double_push(sq, expected):
     assert result == expected
 
 
+def test_white_single_push_blocked():
+    pawns = 1 << 12  # e2
+    blocker = 1 << 20  # e3
+    occ = pawns | blocker
+    assert pawn_single_push_targets(pawns, occ, True) == 0
+
+
+def test_white_double_push_blocked_first_step():
+    pawns = 1 << 12  # e2
+    blocker = 1 << 20  # e3
+    occ = pawns | blocker
+    assert pawn_double_push_targets(pawns, occ, True) == 0
+
+
+def test_white_double_push_blocked_landing():
+    pawns = 1 << 12  # e2
+    blocker = 1 << 28  # e4
+    occ = pawns | blocker
+    assert pawn_double_push_targets(pawns, occ, True) == 0
+
+
+def test_black_single_push_blocked():
+    pawns = 1 << 52  # e7
+    blocker = 1 << 44  # e6
+    occ = pawns | blocker
+    assert pawn_single_push_targets(pawns, occ, False) == 0
+
+
+def test_black_double_push_blocked_first_step():
+    pawns = 1 << 52  # e7
+    blocker = 1 << 44  # e6
+    occ = pawns | blocker
+    assert pawn_double_push_targets(pawns, occ, False) == 0
+
+
+def test_black_double_push_blocked_landing():
+    pawns = 1 << 52  # e7
+    blocker = 1 << 36  # e5
+    occ = pawns | blocker
+    assert pawn_double_push_targets(pawns, occ, False) == 0
+
+
 # Combined black push targets
 def test_black_push_targets_union():
     sq = 52  # e7
@@ -255,3 +297,23 @@ def test_generate_black_pawn_promotion_moves():
     moves = generate_pawn_moves(pawns, 0, pawns, False)
     promos = {m.promotion for m in moves}
     assert promos == {"Q", "R", "B", "N"}
+
+
+def test_white_capture_promotion_moves():
+    pawns = 1 << 54  # g7
+    enemy = 1 << 63  # h8
+    all_occ = pawns | enemy
+    moves = generate_pawn_moves(pawns, enemy, all_occ, True)
+    promos = {m.promotion for m in moves if m.dst == 63 and m.capture}
+    assert promos == {"Q", "R", "B", "N"}
+    assert len([m for m in moves if m.dst == 63]) == 4
+
+
+def test_black_capture_promotion_moves():
+    pawns = 1 << 9  # b2
+    enemy = 1 << 0  # a1
+    all_occ = pawns | enemy
+    moves = generate_pawn_moves(pawns, enemy, all_occ, False)
+    promos = {m.promotion for m in moves if m.dst == 0 and m.capture}
+    assert promos == {"Q", "R", "B", "N"}
+    assert len([m for m in moves if m.dst == 0]) == 4

--- a/python-implementation/tests/bitboard_tests/test_utils.py
+++ b/python-implementation/tests/bitboard_tests/test_utils.py
@@ -1,4 +1,4 @@
-from engine.bitboard.utils import pop_lsb, bit_count, lsb, msb
+from engine.bitboard.utils import pop_lsb, bit_count, lsb, msb, expand_occupancy
 
 
 def test_pop_lsb_nonzero():
@@ -28,3 +28,21 @@ def test_msb():
     assert msb(0b1011000) == 6
     assert msb(1 << 60) == 60
     assert msb(0) is None
+
+
+def test_expand_occupancy_basic():
+    mask = (1 << 1) | (1 << 4)
+    assert expand_occupancy(0, mask) == 0
+    assert expand_occupancy(1, mask) == (1 << 1)
+    assert expand_occupancy(2, mask) == (1 << 4)
+    assert expand_occupancy(3, mask) == mask
+
+
+def test_expand_occupancy_larger_mask():
+    mask = 0
+    bits = [0, 3, 8, 12]
+    for b in bits:
+        mask |= 1 << b
+    subset = 0b1010  # select bits at indices 1 and 3 -> squares bits[1]=3, bits[3]=12
+    expected = (1 << bits[1]) | (1 << bits[3])
+    assert expand_occupancy(subset, mask) == expected


### PR DESCRIPTION
## Summary
- add occupancy tests in bitboard init
- cover expand_occupancy helper
- check pawn push obstructions and capture promotions
- ensure knights ignore friendly pieces
- round trip capture-promotion in make/undo
- add lightweight magic-table tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6734f2a8833195f312edba7d6072