### PR TITLE
Add attack_utils helper and update board

### DIFF
--- a/python-implementation/engine/bitboard/attack_utils.py
+++ b/python-implementation/engine/bitboard/attack_utils.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from engine.bitboard.moves.knight import KNIGHT_ATTACKS
+from engine.bitboard.moves.bishop import bishop_attacks
+from engine.bitboard.moves.rook import rook_attacks
+from engine.bitboard.constants import (
+    WHITE_PAWN,
+    BLACK_PAWN,
+    WHITE_KNIGHT,
+    BLACK_KNIGHT,
+    WHITE_BISHOP,
+    BLACK_BISHOP,
+    WHITE_ROOK,
+    BLACK_ROOK,
+    WHITE_QUEEN,
+    BLACK_QUEEN,
+    WHITE_KING,
+    BLACK_KING,
+    WHITE,
+    BLACK,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .board import Board
+
+
+def is_square_attacked(board: "Board", square: int, attacker_side: int) -> bool:
+    """Return True if ``square`` is attacked by ``attacker_side``."""
+    all_occ = board.white_occ | board.black_occ
+
+    # 1. Pawn attacks
+    if attacker_side == WHITE:
+        pawn_bb = board.bitboards[WHITE_PAWN]
+        mask = 0
+        if square >= 9 and (square % 8) != 7:
+            mask |= 1 << (square - 9)
+        if square >= 7 and (square % 8) != 0:
+            mask |= 1 << (square - 7)
+        if pawn_bb & mask:
+            return True
+    else:
+        pawn_bb = board.bitboards[BLACK_PAWN]
+        mask = 0
+        if square <= 56 and (square % 8) != 7:
+            mask |= 1 << (square + 7)
+        if square <= 55 and (square % 8) != 0:
+            mask |= 1 << (square + 9)
+        if pawn_bb & mask:
+            return True
+
+    # 2. Knight attacks
+    knight_bb = (
+        board.bitboards[WHITE_KNIGHT]
+        if attacker_side == WHITE
+        else board.bitboards[BLACK_KNIGHT]
+    )
+    if KNIGHT_ATTACKS[square] & knight_bb:
+        return True
+
+    # 3. Bishop/Queen diagonal attacks
+    diagonal_attackers = (
+        board.bitboards[WHITE_BISHOP] | board.bitboards[WHITE_QUEEN]
+        if attacker_side == WHITE
+        else board.bitboards[BLACK_BISHOP] | board.bitboards[BLACK_QUEEN]
+    )
+    if bishop_attacks(square, all_occ) & diagonal_attackers:
+        return True
+
+    # 4. Rook/Queen orthogonal attacks
+    orthogonal_attackers = (
+        board.bitboards[WHITE_ROOK] | board.bitboards[WHITE_QUEEN]
+        if attacker_side == WHITE
+        else board.bitboards[BLACK_ROOK] | board.bitboards[BLACK_QUEEN]
+    )
+    if rook_attacks(square, all_occ) & orthogonal_attackers:
+        return True
+
+    # 5. King attacks (adjacent)
+    from engine.bitboard.moves.king import KING_ATTACKS
+
+    king_bb = (
+        board.bitboards[WHITE_KING]
+        if attacker_side == WHITE
+        else board.bitboards[BLACK_KING]
+    )
+    if KING_ATTACKS[square] & king_bb:
+        return True
+
+    return False

--- a/python-implementation/engine/bitboard/board.py
+++ b/python-implementation/engine/bitboard/board.py
@@ -2,10 +2,7 @@ from typing import List
 
 from engine.bitboard.move import Move  # noqa: TC002
 from engine.bitboard.undo import Undo
-from engine.bitboard.moves.king import KING_ATTACKS
-from engine.bitboard.moves.knight import KNIGHT_ATTACKS
-from engine.bitboard.moves.rook import rook_attacks
-from engine.bitboard.moves.bishop import bishop_attacks
+from .attack_utils import is_square_attacked as _is_square_attacked
 from engine.bitboard.constants import (
     INITIAL_MASKS,
     WHITE_PAWN,
@@ -128,74 +125,8 @@ class Board:
         self.all_occ = self.white_occ | self.black_occ
 
     def is_square_attacked(self, square: int, attacker_side: int) -> bool:
-        """
-        Return True if `square` (0..63) is attacked by any piece
-        of color `attacker_side` (WHITE or BLACK).
-        """
-        all_occ = self.white_occ | self.black_occ
-
-        # 1. Pawn attacks:
-        if attacker_side == WHITE:
-            pawn_bb = self.bitboards[WHITE_PAWN]
-            mask = 0
-            if square >= 9 and (square % 8) != 7:
-                mask |= 1 << (square - 9)
-            if square >= 7 and (square % 8) != 0:
-                mask |= 1 << (square - 7)
-            if pawn_bb & mask:
-                return True
-        else:
-            pawn_bb = self.bitboards[BLACK_PAWN]
-            mask = 0
-            if square <= 56 and (square % 8) != 7:
-                mask |= 1 << (square + 7)
-            if square <= 55 and (square % 8) != 0:
-                mask |= 1 << (square + 9)
-            if pawn_bb & mask:
-                return True
-
-        # 2. Knight attacks
-        if attacker_side == WHITE:
-            knight_bb = self.bitboards[WHITE_KNIGHT]
-        else:
-            knight_bb = self.bitboards[BLACK_KNIGHT]
-        if KNIGHT_ATTACKS[square] & knight_bb:
-            return True
-
-        # 3. Bishop/Queen diagonal attacks
-        if attacker_side == WHITE:
-            diagonal_attackers = (
-                self.bitboards[WHITE_BISHOP] | self.bitboards[WHITE_QUEEN]
-            )
-        else:
-            diagonal_attackers = (
-                self.bitboards[BLACK_BISHOP] | self.bitboards[BLACK_QUEEN]
-            )
-
-        if bishop_attacks(square, all_occ) & diagonal_attackers:
-            return True
-
-        # 4. Rook/Queen orthogonal attacks
-        if attacker_side == WHITE:
-            orthogonal_attackers = (
-                self.bitboards[WHITE_ROOK] | self.bitboards[WHITE_QUEEN]
-            )
-        else:
-            orthogonal_attackers = (
-                self.bitboards[BLACK_ROOK] | self.bitboards[BLACK_QUEEN]
-            )
-        if rook_attacks(square, all_occ) & orthogonal_attackers:
-            return True
-
-        # 5. King attacks (adjacent)
-        if attacker_side == WHITE:
-            king_bb = self.bitboards[WHITE_KING]
-        else:
-            king_bb = self.bitboards[BLACK_KING]
-        if KING_ATTACKS[square] & king_bb:
-            return True
-
-        return False
+        """Return ``True`` if ``square`` is attacked by ``attacker_side``."""
+        return _is_square_attacked(self, square, attacker_side)
 
     def make_move(self, move: Move):
         """

--- a/python-implementation/engine/bitboard/generator.py
+++ b/python-implementation/engine/bitboard/generator.py
@@ -106,6 +106,7 @@ def generate_moves(board: Board) -> list[Move]:
     )
 
     moves += generate_king_moves(
+        board,
         board.bitboards[WHITE_KING if is_white else BLACK_KING],
         my_occ,
         their_occ,

--- a/python-implementation/engine/bitboard/moves/king.py
+++ b/python-implementation/engine/bitboard/moves/king.py
@@ -1,7 +1,22 @@
-from typing import List
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+
 from engine.bitboard.move import Move  # noqa: TC002
 from engine.bitboard.utils import pop_lsb
-from engine.bitboard.constants import KING_OFFSETS, FILE_A, FILE_H
+from engine.bitboard.constants import (
+    KING_OFFSETS,
+    FILE_A,
+    FILE_H,
+    WHITE,
+    BLACK,
+    WHITE_ROOK,
+    BLACK_ROOK,
+)
+from engine.bitboard.attack_utils import is_square_attacked
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from engine.bitboard.board import Board
 
 
 def one_king_mask(sq):
@@ -28,7 +43,10 @@ for i in range(len(KING_ATTACKS)):
 
 
 def generate_king_moves(
-    king_bb: int, my_occ: int, their_occ: int
+    board: "Board",
+    king_bb: int,
+    my_occ: int,
+    their_occ: int,
 ) -> List[Move]:
     """
     Appends all legal one-square king moves for the side to move.
@@ -47,5 +65,60 @@ def generate_king_moves(
         targets &= targets - 1
         is_capture = bool((1 << dst) & their_occ)
         moves.append(Move(src, dst, capture=is_capture))
+
+    # Castling moves
+    side = WHITE if board.side_to_move == WHITE else BLACK
+    if side == WHITE:
+        rights = board.castling_rights
+        # White kingside
+        if rights & 0b0001 and src == 4:
+            empty = not (board.all_occ & ((1 << 5) | (1 << 6)))
+            rook_ready = board.bitboards[WHITE_ROOK] & (1 << 7)
+            if (
+                empty
+                and rook_ready
+                and not is_square_attacked(board, 4, BLACK)
+                and not is_square_attacked(board, 5, BLACK)
+                and not is_square_attacked(board, 6, BLACK)
+            ):
+                moves.append(Move(src, 6))
+
+        # White queenside
+        if rights & 0b0010 and src == 4:
+            empty = not (board.all_occ & ((1 << 1) | (1 << 2) | (1 << 3)))
+            rook_ready = board.bitboards[WHITE_ROOK] & (1 << 0)
+            if (
+                empty
+                and rook_ready
+                and not is_square_attacked(board, 4, BLACK)
+                and not is_square_attacked(board, 3, BLACK)
+                and not is_square_attacked(board, 2, BLACK)
+            ):
+                moves.append(Move(src, 2))
+    else:
+        rights = board.castling_rights
+        if rights & 0b0100 and src == 60:
+            empty = not (board.all_occ & ((1 << 61) | (1 << 62)))
+            rook_ready = board.bitboards[BLACK_ROOK] & (1 << 63)
+            if (
+                empty
+                and rook_ready
+                and not is_square_attacked(board, 60, WHITE)
+                and not is_square_attacked(board, 61, WHITE)
+                and not is_square_attacked(board, 62, WHITE)
+            ):
+                moves.append(Move(src, 62))
+
+        if rights & 0b1000 and src == 60:
+            empty = not (board.all_occ & ((1 << 57) | (1 << 58) | (1 << 59)))
+            rook_ready = board.bitboards[BLACK_ROOK] & (1 << 56)
+            if (
+                empty
+                and rook_ready
+                and not is_square_attacked(board, 60, WHITE)
+                and not is_square_attacked(board, 59, WHITE)
+                and not is_square_attacked(board, 58, WHITE)
+            ):
+                moves.append(Move(src, 58))
 
     return moves

--- a/python-implementation/tests/bitboard_tests/test_king.py
+++ b/python-implementation/tests/bitboard_tests/test_king.py
@@ -23,6 +23,9 @@ def test_king_moves_open_board():
     board.white_occ = board.bitboards[WHITE_KING]
     board.black_occ = board.all_occ = 0
     moves = generate_king_moves(
-        board.bitboards[WHITE_KING], board.white_occ, board.black_occ
+        board,
+        board.bitboards[WHITE_KING],
+        board.white_occ,
+        board.black_occ,
     )
     assert len(moves) == 8


### PR DESCRIPTION
## Summary
- extract `is_square_attacked` helper into `attack_utils.py`
- delegate `Board.is_square_attacked` to the helper
- extend king move generation to accept board and check castling attacks
- adjust move generator and unit tests accordingly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a91bd94c8331a5ac2263c47ce2e6