### PR TITLE
Add AGENTS guidelines for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS Instructions
+
+This project contains a chess engine written in Python. Follow these rules when contributing or automating changes.
+
+## Style Guidelines
+
+- **Python:** Adhere to [PEP 8](https://peps.python.org/pep-0008/). Use `classify-imports --apply` to keep imports grouped and sorted.
+- Use `flake8` with the configuration from `requirements.txt` to lint the code.
+- Keep code comments where logic is non-trivial, especially in bitboard or search modules.
+
+## Testing
+
+- Run `pytest` from the repository root (`python-implementation/tests`) before committing.
+- Continuous integration expects tests to pass on Python 3.13.
+
+## Pull Requests
+
+- Ensure CI checks pass (`flake8` and `pytest`).
+- Summaries should reference any closed issues (e.g., `Closes #123`).
+- Describe the changes succinctly.
+


### PR DESCRIPTION
## Summary
- define project instructions for codex agents and contributors

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6840ad2dd1cc8331bc051415322ce723