### PR TITLE
Add in_check tests and fix bitboard board

### DIFF
--- a/python-implementation/engine/bitboard/board.py
+++ b/python-implementation/engine/bitboard/board.py
@@ -140,7 +140,7 @@ class Board:
 
         king_sq = king_bb.bit_length() - 1
         attacker = BLACK if side == WHITE else WHITE
-        return _is_square_attacked(king_sq, attacker)
+        return _is_square_attacked(self, king_sq, attacker)
 
     def make_move(self, move: Move):
         """

--- a/python-implementation/tests/bitboard_tests/test_in_check.py
+++ b/python-implementation/tests/bitboard_tests/test_in_check.py
@@ -1,0 +1,49 @@
+from engine.bitboard.board import Board
+from engine.bitboard.constants import (
+    WHITE,
+    BLACK,
+    WHITE_KING,
+    BLACK_KING,
+    BLACK_QUEEN,
+    WHITE_QUEEN,
+)
+
+PIECE_INDEX = {
+    "K": WHITE_KING,
+    "k": BLACK_KING,
+    "q": BLACK_QUEEN,
+    "Q": WHITE_QUEEN,
+}
+
+
+def sq(file: int, rank: int) -> int:
+    return (rank - 1) * 8 + (file - 1)
+
+
+def make_board(pieces: dict[int, str]) -> Board:
+    board = Board()
+    board.bitboards = [0] * 12
+    for square, char in pieces.items():
+        board.bitboards[PIECE_INDEX[char]] |= 1 << square
+    board.update_occupancies()
+    return board
+
+
+def test_white_in_check() -> None:
+    board = make_board({sq(5, 1): "K", sq(5, 8): "q"})
+    assert board.in_check(WHITE)
+
+
+def test_black_not_in_check() -> None:
+    board = make_board({sq(5, 8): "k"})
+    assert not board.in_check(BLACK)
+
+
+def test_black_in_check_from_white_queen() -> None:
+    board = make_board({sq(5, 8): "k", sq(5, 1): "Q"})
+    assert board.in_check(BLACK)
+
+
+def test_missing_king_returns_false() -> None:
+    board = make_board({})
+    assert not board.in_check(WHITE)

--- a/python-implementation/tests/bitboard_tests/test_utils.py
+++ b/python-implementation/tests/bitboard_tests/test_utils.py
@@ -1,4 +1,10 @@
-from engine.bitboard.utils import pop_lsb, bit_count, lsb, msb, expand_occupancy
+from engine.bitboard.utils import (
+    pop_lsb,
+    bit_count,
+    lsb,
+    msb,
+    expand_occupancy,
+)
 
 
 def test_pop_lsb_nonzero():
@@ -43,6 +49,6 @@ def test_expand_occupancy_larger_mask():
     bits = [0, 3, 8, 12]
     for b in bits:
         mask |= 1 << b
-    subset = 0b1010  # select bits at indices 1 and 3 -> squares bits[1]=3, bits[3]=12
+    subset = 0b1010  # indices 1 and 3 -> squares bits[1]=3, bits[3]=12
     expected = (1 << bits[1]) | (1 << bits[3])
     assert expand_occupancy(subset, mask) == expected

--- a/python-implementation/tests/mailbox_tests/test_perft.py
+++ b/python-implementation/tests/mailbox_tests/test_perft.py
@@ -173,10 +173,10 @@ def test_perft_hashed_matches_naive(depth):
 
 #     # Print results (pytest -s to see them)
 #     print(
-#         f"\nperft(depth={depth}): naive={t_naive:.3f}s, hashed={t_hashed:.3f}s"
+#         f"\nperft(depth={depth}): naive={t_naive:.3f}s, hashed={t_hashed:.3f}s"  # noqa: E501
 #     )
 
 #     # We expect some speedup
 #     assert (
 #         t_hashed < t_naive
-#     ), f"Expected hashed perft to be faster: {t_hashed:.3f}s vs {t_naive:.3f}s"
+#     ), f"Expected hashed perft to be faster: {t_hashed:.3f}s vs {t_naive:.3f}s"  # noqa: E501


### PR DESCRIPTION
## Summary
- fix `in_check` implementation using board context
- adjust some long lines in tests
- ignore flake8 warnings in perft test
- add coverage tests for `Board.in_check`

## Testing
- `flake8`
- `pytest python-implementation/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c936e46883319b506f28f3a5a28a