### PR TITLE
Add bitboard perft tests

### DIFF
--- a/python-implementation/engine/bitboard/move.py
+++ b/python-implementation/engine/bitboard/move.py
@@ -37,3 +37,16 @@ class Move:
             and self.en_passant == other.en_passant
             and self.castling == other.castling
         )
+
+    def __hash__(self) -> int:  # noqa: D401 - trivial hashing
+        """Return a hash based on move attributes."""
+        return hash(
+            (
+                self.src,
+                self.dst,
+                self.capture,
+                self.promotion,
+                self.en_passant,
+                self.castling,
+            )
+        )

--- a/python-implementation/tests/bitboard_tests/test_perft.py
+++ b/python-implementation/tests/bitboard_tests/test_perft.py
@@ -1,0 +1,47 @@
+import pytest
+
+from engine.bitboard.board import Board
+from engine.bitboard.generator import generate_legal_moves
+from engine.bitboard.perft import perft, perft_divide
+
+
+def test_perft_depth_zero_is_one():
+    b = Board()
+    assert perft(b, 0) == 1
+
+
+def test_perft_depth_one_equals_legal_moves():
+    b = Board()
+    moves = generate_legal_moves(b)
+    assert perft(b, 1) == len(moves)
+
+
+@pytest.mark.parametrize(
+    "depth,expected",
+    [
+        (1, 20),
+        (2, 400),
+        (3, 8902),
+    ],
+)
+def test_perft_start_position(depth, expected):
+    b = Board()
+    assert perft(b, depth) == expected
+
+
+def test_perft_divide_depth_one_sums_to_perft():
+    b = Board()
+    total = perft(b, 1)
+    divide = perft_divide(b, 1)
+    assert sum(divide.values()) == total
+    assert all(cnt == 1 for cnt in divide.values())
+    legal_moves = generate_legal_moves(b)
+    assert set(divide.keys()) == set(legal_moves)
+
+
+def test_perft_divide_consistency_with_depth_two():
+    b = Board()
+    total2 = perft(b, 2)
+    divide2 = perft_divide(b, 2)
+    assert sum(divide2.values()) == total2
+    assert any(cnt > 1 for cnt in divide2.values())


### PR DESCRIPTION
## Summary
- make `Move` hashable so it works as a dict key
- add tests for bitboard `perft` and `perft_divide`

## Testing
- `flake8`
- `pytest -c python-implementation/pytest.ini python-implementation/tests`

------
https://chatgpt.com/codex/tasks/task_e_684149d749748331b4084a1cdde85aad