### PR TITLE
Fix mailbox perft mismatch

### DIFF
--- a/python-implementation/engine/mailbox/board.py
+++ b/python-implementation/engine/mailbox/board.py
@@ -302,8 +302,13 @@ class Board:
         # ──────────────────────────────────────────────────────────
         # Captures (including en‑passant)
         # ──────────────────────────────────────────────────────────
-        if self.en_passant_target and to_sq == self.en_passant_target:
-            # en‑passant capture
+        if (
+            piece.upper() == "P"
+            and self.en_passant_target
+            and to_sq == self.en_passant_target
+            and abs(to_sq[0] - from_sq[0]) == 1
+        ):
+            # en‑passant capture (only for pawn diagonals)
             move.is_en_passant = True
             direction = 1 if piece.isupper() else -1
             cap_sq = (to_sq[0], to_sq[1] - direction)

--- a/python-implementation/tests/mailbox_tests/test_perft.py
+++ b/python-implementation/tests/mailbox_tests/test_perft.py
@@ -47,7 +47,12 @@ def test_perft_depth_one_equals_legal_moves():
 
 @pytest.mark.parametrize(
     "depth,expected",
-    [(1, 20), (2, 400), (3, 8902)],
+    [
+        (1, 20),
+        (2, 400),
+        (3, 8902),
+        (4, 197281),
+    ],
 )
 def test_perft_starting_position(depth, expected):
     b = make_start_board()


### PR DESCRIPTION
## Summary
- ensure en passant capture triggers only for pawn diagonals
- restore mailbox perft depth 4 regression test

## Testing
- `flake8`
- `PYTHONPATH=python-implementation pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843357c184c8331b9991e0931c078a9