### PR TITLE
Add simple UCI interface

### DIFF
--- a/python-implementation/engine/uci.py
+++ b/python-implementation/engine/uci.py
@@ -1,0 +1,48 @@
+# engine/uci.py
+
+"""Minimal UCI interface backed by the bitboard engine."""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+from engine.bitboard.board import Board
+from engine.bitboard.perft import perft_count
+
+
+def main() -> None:
+    board: Optional[Board] = Board()
+    for raw in sys.stdin:
+        cmd = raw.strip()
+        if not cmd:
+            continue
+        parts = cmd.split()
+        token = parts[0]
+
+        if token == "uci":
+            print("id name chess-bots")
+            print("id author Vaishak Menon")
+            print("uciok")
+        elif token == "isready":
+            print("readyok")
+        elif token == "position":
+            if len(parts) >= 2 and parts[1] == "startpos":
+                board = Board()
+            elif len(parts) >= 8 and parts[1] == "fen":
+                fen = " ".join(parts[2:8])
+                board = Board()
+                board.set_fen(fen)
+        elif token == "go" and len(parts) == 3 and parts[1] == "depth":
+            if board is not None:
+                depth = int(parts[2])
+                nodes = perft_count(board, depth)
+                print(f"info nodes {nodes}")
+                print("bestmove 0000")
+        elif token in {"quit", "stop"}:
+            break
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/python-implementation/tests/test_uci.py
+++ b/python-implementation/tests/test_uci.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_uci_smoke():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "engine.uci"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+    )
+    cmds = "uci\nisready\nposition startpos\ngo depth 1\nquit\n"
+    out, _ = proc.communicate(cmds, timeout=5)
+    assert "uciok" in out
+    assert "readyok" in out
+    assert "bestmove" in out


### PR DESCRIPTION
## Summary
- implement a bare-bones UCI driver that uses the bitboard board
- expose commands `uci`, `isready`, `position`, and `go depth`
- add a smoke test that spawns the module and exercises the basic protocol

## Testing
- `flake8`
- `pytest python-implementation/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684b315a800c8331898272474f980e75